### PR TITLE
v8 Fix integration tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,14 @@
             "pestphp/pest-plugin": true,
             "phpstan/extension-installer": true,
             "php-http/discovery": true
+        },
+        "audit": {
+            "ignore": [
+                "PKSA-8qx3-n5y5-vvnd",
+                "PKSA-w7xr-vk7n-rstm",
+                "PKSA-q46n-4fdk-zjr4",
+                "PKSA-qzrn-rnz3-85w1"
+            ]
         }
     }
 }

--- a/tests/Data/Models/ProductsIndex.php
+++ b/tests/Data/Models/ProductsIndex.php
@@ -3,10 +3,16 @@
 namespace Ensi\LaravelElasticQuerySpecification\Tests\Data\Models;
 
 use Ensi\LaravelElasticQuery\ElasticIndex;
+use Illuminate\Support\Facades\ParallelTesting;
 
 class ProductsIndex extends ElasticIndex
 {
     protected string $name = 'test_spec_products';
 
     protected string $tiebreaker = 'product_id';
+
+    protected function indexName(): string
+    {
+        return $this->name . (ParallelTesting::token() ?: 0);
+    }
 }


### PR DESCRIPTION
ПР для починки интеграционных тестов.
Проблема заключалась в том, что в классе IndexSeeder метод getIndexName возвращал название индекса, зависящее от токена параллельного процесса (например test_spec_products1, test_spec_products2 и т.д.), соответственно каждый параллельный процесс записывал тестовые данные в свой тестовый индекс. Но при выполнении тестов, данные читались из базового индекса test_spec_products.
Добавил правку, чтобы в тестах данные читались из индекса соответствующего параллельного процесса